### PR TITLE
Enhance composition functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ If selection is controlled externally, defines an array of ids of rows that are 
 #### renderExpansion (rowData)
 Defines the component to be rendered in the expansion area if a row is pressed. Should not be used in conjunction with onRowPress (see below)
 
+#### renderTopLeftComponent (function)
+Defines the component to be rendered in the top left corner of the page, above the search bar and data table
+
+#### renderTopRightComponent (rowData)
+Defines the component to be rendered in the top right corner of the page, to the right of the search bar and above the data table
+
 #### onRowPress (rowData)
 Allows defining some custom behaviour on pressing a row, e.g. navigating to a drilled down view related to the row's data. Called when a row is pressed with the rowData as the single argument. Should not be provided if rows are not pressable, or if renderExpansion is provided
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Defines the column to sort on by default
 #### searchKey (string)
 Defines the column to filter on when the user types in the search bar
 
+#### onSearchChange (function)
+Callback with search term when user enters different info into search bar. In case you want to filter data externally.
+
 #### footerData (object)
 If passed in, defines data to display in a footer row that is always rendered at the bottom of the
 data table

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ A callback with the array of ids representing all rows with a checkable cell tur
 #### selection (array)
 If selection is controlled externally, defines an array of ids of rows that are 'selected', i.e. a checkable cell is turned on in that row
 
-#### onRowPress (rowData)
-Called when a row is pressed with the rowData as the single argument. Should not be provided if rows are not pressable, or if renderExpansion is provided
-
 #### renderExpansion (rowData)
-Defines the component to be rendered in the expansion area if a row is pressed. Should not be used in conjuction with onRowPress (see above)
+Defines the component to be rendered in the expansion area if a row is pressed. Should not be used in conjunction with onRowPress (see below)
+
+#### onRowPress (rowData)
+Allows defining some custom behaviour on pressing a row, e.g. navigating to a drilled down view related to the row's data. Called when a row is pressed with the rowData as the single argument. Should not be provided if rows are not pressable, or if renderExpansion is provided
 
 #### rowHeight (integer)
 Sets the height of the rows in the data table.

--- a/README.md
+++ b/README.md
@@ -11,35 +11,51 @@ contains a searchable table.
 
 ## Usage
 
-The customisation can be done through either composition or inheritance. We recommend using composition. We have used inheritance successfully in the mSupply mobile project, but to keep a consistent react-style architecture we would prefer that future projects simply expose more props and use composition rather than using the method overriding.
-
-For working examples of usage, see [MoneyMob](https://github.com/sussol/moneymob) for composition, and [mSupply Mobile](https://github.com/sussol/mobile) for inheritance.
+For working examples of usage, see [mSupply Mobile](https://github.com/sussol/mobile).
 
 ### Required Props
 
-#### columns (array), or assign this.state.columns in the constructor if using inheritance
+#### columns (array)
 An array of objects defining each of the columns. Each entry must contain the 'key' (string), 'width' (integer), and 'title' (string) of the column. Each may optionally contain 'sortable' (boolean).
 
-#### data (array), or override getFilteredSortedData if using inheritance (see [below](#optional-methods))
+#### data (array)
 Defines the data displayed in the table, ready for sorting and filtering
 
 ### Optional Props
 
+#### refreshData(searchTerm, sortBy, isAscending)
+This method should filter the data to match the given parameters, and update the 'data' prop passed in. If provided, the generic table page will display a search bar. If not provided, the generic table page will take care of sorting internally, as well as filtering if 'searchKey' is provided (see below)
+
+#### searchKey (string)
+Defines the column to filter on when the user types in the search bar. If provided, the page will display a search bar. Don't provide if you control data filtering externally using refreshData (see above)
+
 #### defaultSortKey (string)
 Defines the column to sort on by default
 
-#### searchKey (string)
-Defines the column to filter on when the user types in the search bar
-
-#### onSearchChange (function)
-Callback with search term when user enters different info into search bar. In case you want to filter data externally.
+#### defaultSortDirection (string)
+Either 'ascending' or 'descending', defines which direction to sort the data initially
 
 #### footerData (object)
 If passed in, defines data to display in a footer row that is always rendered at the bottom of the
 data table
 
-#### onRowPress (function)
-Called when a row is pressed with the rowData as the single argument
+#### renderCell(key, record)
+This method defines how each cell is rendered, given the column key and database record. The default method returns a simple string, which will be rendered in a static text cell. Alternative formats are listed in the method comment within index.js
+
+#### onEndEditing(key, rowData, newValue)
+Carries out any response required when an editable cell is edited. The obvious example is saving the new value to the database.
+
+#### onSelectionChange(newSelection)
+A callback with the array of ids representing all rows with a checkable cell turned 'on'
+
+#### selection (array)
+If selection is controlled externally, defines an array of ids of rows that are 'selected', i.e. a checkable cell is turned on in that row
+
+#### onRowPress (rowData)
+Called when a row is pressed with the rowData as the single argument. Should not be provided if rows are not pressable, or if renderExpansion is provided
+
+#### renderExpansion (rowData)
+Defines the component to be rendered in the expansion area if a row is pressed. Should not be used in conjuction with onRowPress (see above)
 
 #### rowHeight (integer)
 Sets the height of the rows in the data table.
@@ -65,6 +81,9 @@ See github.com/sussol/react-native-data-table for details
 #### searchBarColor (string)
 Sets the color of the search bar, see github.com/sussol/react-native-ui-components for details
 
+#### searchBarPlaceholderText (string)
+The placeholder text for the search bar
+
 #### colors (object)
 Sets the color of components within the data table, including
 * checkableCellDisabled
@@ -72,20 +91,5 @@ Sets the color of components within the data table, including
 * checkableCellUnchecked
 * editableCellUnderline
 
-#### topRoute (boolean)
-Whether this page is on top of the navigation stack. Determines whether it will refresh the page's data if a change is detected.
-
-### Optional Methods (If Using Inheritance)
-If inheriting, the class provided by this library will be extended by an implementing class. This implementation class has the opportunity to override methods to customise the look and functionality of the generic table page. See inline comments in index.js for more info.
-
-#### getFilteredSortedData(searchTerm, sortBy, isAscending)
-This method should return a refreshed realm results object containing data that matches the given parameters. If not overridden, must pass in 'data' to be sorted and filtered using the default method
-
-#### renderCell(key, record)
-This method defines how each cell is rendered, given the column key and database record. The default method returns a simple string, which will be rendered in a static text cell. Alternative formats are listed in the method comment within index.js
-
-#### onRowPress(key, rowData)
-Carries out any response required to a row being pressed. Should not be overridden if the rows are not pressable.
-
-#### onEndEditing(key, rowData, newValue)
-Carries out any response required when an editable cell is edited. The obvious example is saving the new value to the database.
+#### children (array)
+Any children passed in will be rendered below the data table (useful for modals)

--- a/index.js
+++ b/index.js
@@ -281,7 +281,9 @@ export class GenericTablePage extends React.Component {
     const cells = [];
     const isExpanded = this.state.expandedRows.includes(rowData.id);
     // Make rows alternate background colour
-    const rowStyle = rowId % 2 === 1 ? row : [row, { backgroundColor: 'white' }];
+    const rowStyle = rowId % 2 === 1 ?
+                     row :
+                     [row, { backgroundColor: row.alternateBackgroundColor || 'white' }];
 
     this.props.columns.forEach((column, index, columns) => {
       let textStyle;

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ export class GenericTablePage extends React.Component {
   componentWillReceiveProps(props) {
     if (!this.props.topRoute && props.topRoute) this.refreshData();
     if (this.props.data !== props.data) {
-      this.setData(props.data);
+      this.refreshData(props);
     }
   }
 
@@ -166,10 +166,13 @@ export class GenericTablePage extends React.Component {
     }
   }
 
-  refreshData() {
+  refreshData(props) {
     this.cellRefsMap = {};
     const { searchTerm, sortBy, isAscending } = this.state;
-    const filteredSortedData = this.getFilteredSortedData(searchTerm, sortBy, isAscending);
+    const filteredSortedData = this.getFilteredSortedData(searchTerm,
+                                                          sortBy,
+                                                          isAscending,
+                                                          props || this.props);
     this.setData(filteredSortedData);
   }
 
@@ -177,8 +180,8 @@ export class GenericTablePage extends React.Component {
     this.setState({ dataSource: this.state.dataSource.cloneWithRows(data) });
   }
 
-  getFilteredSortedData(searchTerm, sortBy, isAscending) {
-    const { data, searchKey } = this.props;
+  getFilteredSortedData(searchTerm, sortBy, isAscending, props) {
+    const { data, searchKey } = props;
     // Filter by searchKey, or if none was passed in props, return full set of data
     let results = searchKey ? filterObjectArray(data, searchKey, searchTerm) : data;
     results = sortObjectArray(results, sortBy, isAscending);

--- a/index.js
+++ b/index.js
@@ -58,9 +58,9 @@ export class GenericTablePage extends React.Component {
     this.state = {
       dataSource: dataSource,
       searchTerm: '',
-      sortBy: props.defaultSortKey || '',
-      isAscending: props.defaultSortDirection ? props.defaultSortDirection === 'ascending' : true,
-      selection: props.selection || [],
+      sortBy: props.defaultSortKey,
+      isAscending: props.defaultSortDirection === 'ascending',
+      selection: props.selection,
       expandedRows: [],
     };
     this.cellRefsMap = {}; // { rowId: reference, rowId: reference, ...}
@@ -503,8 +503,11 @@ GenericTablePage.propTypes = {
 GenericTablePage.defaultProps = {
   columns: [],
   dataTableStyles: {},
+  defaultSortKey: '',
+  defaultSortDirection: 'ascending',
   pageStyles: {},
   rowHeight: 45,
+  selection: [],
 };
 
 const defaultStyles = StyleSheet.create({

--- a/index.js
+++ b/index.js
@@ -404,10 +404,10 @@ export class GenericTablePage extends React.Component {
   }
 
   renderSearchBar() {
-    const { pageStyles, searchBarColor } = this.props;
+    const { pageStyles, onSearchChange, searchBarColor } = this.props;
     return (
       <SearchBar
-        onChange={this.onSearchChange}
+        onChange={onSearchChange || this.onSearchChange}
         style={pageStyles.searchBar}
         color={searchBarColor}
       />);
@@ -439,12 +439,12 @@ export class GenericTablePage extends React.Component {
   }
 
   render() {
-    const { hideSearchBar, pageStyles } = this.props;
+    const { searchKey, onSearchChange, pageStyles } = this.props;
     return (
       <View style={[defaultStyles.pageContentContainer, pageStyles.pageContentContainer]}>
         <View style={[defaultStyles.container, pageStyles.container]}>
           <View style={[defaultStyles.pageTopSectionContainer, pageStyles.pageTopSectionContainer]}>
-            {!hideSearchBar &&
+            {(searchKey || onSearchChange) &&
               <View
                 style={[defaultStyles.pageTopLeftSectionContainer,
                         pageStyles.pageTopLeftSectionContainer]}
@@ -467,8 +467,8 @@ GenericTablePage.propTypes = {
   dataTableStyles: React.PropTypes.object,
   defaultSortKey: React.PropTypes.string,
   footerData: React.PropTypes.object,
-  hideSearchBar: React.PropTypes.bool,
   onRowPress: React.PropTypes.func,
+  onSearchChange: React.PropTypes.func,
   pageStyles: React.PropTypes.object,
   rowHeight: React.PropTypes.number,
   searchBarColor: React.PropTypes.string,

--- a/index.js
+++ b/index.js
@@ -417,6 +417,7 @@ export class GenericTablePage extends React.Component {
         onChange={onSearchChange || this.onSearchChange}
         style={pageStyles.searchBar}
         color={searchBarColor}
+        placeholderText={this.props.searchBarPlaceholderText}
       />);
   }
 
@@ -479,6 +480,7 @@ GenericTablePage.propTypes = {
   pageStyles: React.PropTypes.object,
   rowHeight: React.PropTypes.number,
   searchBarColor: React.PropTypes.string,
+  searchBarPlaceholderText: React.PropTypes.string,
   searchKey: React.PropTypes.string,
   topRoute: React.PropTypes.bool,
 };

--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ export class GenericTablePage extends React.Component {
       rowHasChanged: (row1, row2) => row1 !== row2,
     });
     this.state = {
-      columns: props.columns || [],
       dataSource: dataSource,
       searchTerm: '',
       sortBy: props.defaultSortKey || '',
@@ -90,6 +89,9 @@ export class GenericTablePage extends React.Component {
    */
   componentWillReceiveProps(props) {
     if (!this.props.topRoute && props.topRoute) this.refreshData();
+    if (this.props.data !== props.data) {
+      this.setData(props.data);
+    }
   }
 
   onSearchChange(searchTerm) {
@@ -166,9 +168,13 @@ export class GenericTablePage extends React.Component {
 
   refreshData() {
     this.cellRefsMap = {};
-    const { dataSource, searchTerm, sortBy, isAscending } = this.state;
+    const { searchTerm, sortBy, isAscending } = this.state;
     const filteredSortedData = this.getFilteredSortedData(searchTerm, sortBy, isAscending);
-    this.setState({ dataSource: dataSource.cloneWithRows(filteredSortedData) });
+    this.setData(filteredSortedData);
+  }
+
+  setData(data) {
+    this.setState({ dataSource: this.state.dataSource.cloneWithRows(data) });
   }
 
   getFilteredSortedData(searchTerm, sortBy, isAscending) {
@@ -221,12 +227,12 @@ export class GenericTablePage extends React.Component {
 
   renderHeader() {
     // If no columns have titles, don't render a header
-    if (!this.state.columns.find((column) => column.title && column.title.length > 0)) {
+    if (!this.props.columns.find((column) => column.title && column.title.length > 0)) {
       return null;
     }
     const { header, headerCell, rightMostCell, text } = this.props.dataTableStyles;
     const headerCells = [];
-    this.state.columns.forEach((column, index, columns) => {
+    this.props.columns.forEach((column, index, columns) => {
       let textStyle;
       let cellStyle = index !== columns.length - 1 ? headerCell : [headerCell, rightMostCell];
 
@@ -277,7 +283,7 @@ export class GenericTablePage extends React.Component {
     // Make rows alternate background colour
     const rowStyle = rowId % 2 === 1 ? row : [row, { backgroundColor: 'white' }];
 
-    this.state.columns.forEach((column, index, columns) => {
+    this.props.columns.forEach((column, index, columns) => {
       let textStyle;
       switch (column.alignText) {
         case 'left':
@@ -477,6 +483,7 @@ GenericTablePage.propTypes = {
 };
 
 GenericTablePage.defaultProps = {
+  columns: [],
   dataTableStyles: {},
   pageStyles: {},
   rowHeight: 45,

--- a/index.js
+++ b/index.js
@@ -274,6 +274,7 @@ export class GenericTablePage extends React.Component {
 
   renderRow(rowData, sectionId, rowId) {
     const { checkableCell, rightMostCell, row, text } = this.props.dataTableStyles;
+    const { colors } = this.props;
     // If the rowData has the function 'isValid', check it to see the object still exists
     if (typeof rowData.isValid === 'function' && !rowData.isValid()) {
       return null; // Don't render if the row's data has been deleted
@@ -281,9 +282,7 @@ export class GenericTablePage extends React.Component {
     const cells = [];
     const isExpanded = this.state.expandedRows.includes(rowData.id);
     // Make rows alternate background colour
-    const rowStyle = rowId % 2 === 1 ?
-                     row :
-                     [row, { backgroundColor: row.alternateBackgroundColor || 'white' }];
+    const rowStyle = rowId % 2 === 1 ? row : [row, { backgroundColor: colors.alternateRow }];
 
     this.props.columns.forEach((column, index, columns) => {
       let textStyle;
@@ -328,7 +327,6 @@ export class GenericTablePage extends React.Component {
             iconChecked = 'md-radio-button-on';
             iconNotChecked = 'md-radio-button-off';
           }
-          const { colors } = this.props;
           cell = (
             <CheckableCell
               key={column.key}

--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ export class GenericTablePage extends React.Component {
 
   renderRow(rowData, sectionId, rowId) {
     const { checkableCell, rightMostCell, row, text } = this.props.dataTableStyles;
-    const { colors } = this.props;
+    const { colors = {} } = this.props;
     // If the rowData has the function 'isValid', check it to see the object still exists
     if (typeof rowData.isValid === 'function' && !rowData.isValid()) {
       return null; // Don't render if the row's data has been deleted
@@ -282,7 +282,8 @@ export class GenericTablePage extends React.Component {
     const cells = [];
     const isExpanded = this.state.expandedRows.includes(rowData.id);
     // Make rows alternate background colour
-    const rowStyle = rowId % 2 === 1 ? row : [row, { backgroundColor: colors.alternateRow }];
+    const { alternateRow = 'white' } = colors;
+    const rowStyle = rowId % 2 === 1 ? row : [row, { backgroundColor: alternateRow }];
 
     this.props.columns.forEach((column, index, columns) => {
       let textStyle;

--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ export class GenericTablePage extends React.Component {
         onChange={onSearchChange || this.onSearchChange}
         style={pageStyles.searchBar}
         color={searchBarColor}
-        placeholderText={this.props.searchBarPlaceholderText}
+        placeholder={this.props.searchBarPlaceholderText}
       />);
   }
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ export class GenericTablePage extends React.Component {
       searchTerm: '',
       sortBy: props.defaultSortKey || '',
       isAscending: props.defaultSortDirection ? props.defaultSortDirection === 'ascending' : true,
-      selection: [],
+      selection: props.selection || [],
       expandedRows: [],
     };
     this.cellRefsMap = {}; // { rowId: reference, rowId: reference, ...}
@@ -81,6 +81,10 @@ export class GenericTablePage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.data !== nextProps.data) this.setDataSource(nextProps.data);
+    // If selection is controlled externally, update the state internally to match
+    if (nextProps.selection && this.props.selection !== nextProps.selection) {
+      this.setState({ selection: nextProps.selection });
+    }
   }
 
   onSearchChange(searchTerm) {
@@ -495,6 +499,7 @@ GenericTablePage.propTypes = {
   searchBarColor: PropTypes.string,
   searchBarPlaceholderText: PropTypes.string,
   searchKey: PropTypes.string,
+  selection: PropTypes.array,
   topRoute: PropTypes.bool,
 };
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ import { filterObjectArray, sortObjectArray } from './utilities';
  * Provides a generic implementation of a standard page in a data-centric app, which
  * contains a searchable table. Should always be overridden, in particular the
  * following methods and instance variables (fields):
- * @method getFilteredSortedData(searchTerm, sortBy, isAscending) Should return updated data
+ * @method refreshData(searchTerm, sortBy, isAscending) Should update data prop based on filters
  * @method renderCell(key, record) Should define what to render in a cell with the
  *         											 given column key and database record
  * @method onRowPress(key, rowData) Should define behaviour when a row is pressed,
@@ -484,10 +484,8 @@ GenericTablePage.propTypes = {
   defaultSortDirection: PropTypes.string,
   defaultSortKey: PropTypes.string,
   footerData: PropTypes.object,
-  getFilteredSortedData: PropTypes.func,
   onEndEditing: PropTypes.func,
   onRowPress: PropTypes.func,
-  onSearchChange: PropTypes.func,
   onSelectionChange: PropTypes.func,
   pageStyles: PropTypes.object,
   refreshData: PropTypes.func,
@@ -500,7 +498,6 @@ GenericTablePage.propTypes = {
   searchBarPlaceholderText: PropTypes.string,
   searchKey: PropTypes.string,
   selection: PropTypes.array,
-  topRoute: PropTypes.bool,
 };
 
 GenericTablePage.defaultProps = {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ export class GenericTablePage extends React.Component {
       newSelection.push(rowData.id);
     }
     this.setState({ selection: newSelection });
-    this.onSelectionChange && this.onSelectionChange(newSelection);
+    if (this.props.onSelectionChange) this.props.onSelectionChange(newSelection);
   }
 
   /**
@@ -351,8 +351,8 @@ export class GenericTablePage extends React.Component {
               placeholder={renderedCell.placeholder}
               keyboardType={renderedCell.keyboardType || 'numeric'}
               onEndEditing={(target, value) => {
-                if (!this.onEndEditing) return;
-                this.onEndEditing(column.key, target, value);
+                if (!this.props.onEndEditing) return;
+                this.props.onEndEditing(column.key, target, value);
                 this.refreshData();
               }}
               onSubmitEditing={() => this.focusNextField(parseInt(rowId, 10))}
@@ -481,6 +481,7 @@ GenericTablePage.propTypes = {
   defaultSortKey: PropTypes.string,
   footerData: PropTypes.object,
   getFilteredSortedData: PropTypes.func,
+  onEndEditing: PropTypes.func,
   onRowPress: PropTypes.func,
   onSearchChange: PropTypes.func,
   onSelectionChange: PropTypes.func,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-generic-table-page",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "A customisable page containing a searchable table of data from realm for react native",
   "repository": "https://github.com/sussol/react-native-generic-table-page.git",
   "author": "Sustainable Solutions (NZ) Ltd.",


### PR DESCRIPTION
Note that because columns have been moved from this.state to this.props, this would be a breaking change affecting mSupply Mobile. I think it would be a good idea to move over to the composition model there though, and wouldn’t take too much work, fingers crossed. You can always depend on the old version until that time! (…please?)